### PR TITLE
Added recurse flag and allowed verbose to display file names as processed...

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ I currently have spent about two weeks working on the metrics package and I alre
 
 For more information on Tools and the Hitchhikers Guide to Test Automation please visit:
 http://www.testing-software.org/
+
+Extended 11th Aug 2014 Steve Barnes <gadgetsteve@hotmail.com>
+
+ - Added -r option to recurse directories.
+ - Verbose mode now outputs the file being processed.

--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -5,4 +5,5 @@
     Copyright (c) 2005 by Reg. Charney <charney@charneyday.com>
     All rights reserved, see LICENSE for details.
 """
-__version__ = "0.2.6"
+__version__ = "0.2.6.sjb"
+

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email = 'mark@mark-fink.de',
     description = 'metrics produces metrics for C, C++, Javascript, and Python programs',
     long_description=open('README.md').read(),
-    url = 'https://github.com/metrics/',
+    url = 'https://github.com/markfink/metrics',
     download_url='http://pypi.python.org/pypi/metrics',
     name='metrics',
     version=__version__,


### PR DESCRIPTION
Other than on very small projects it is necessary to create a list of files to process prior to using the package, this can be inconvenient and/or confusing for some users so this adds a -r dir_name option to allow recursive parsing.
As verbose in the original code does very little made use of this flag to display file names as processing continues.

Also fixed two exceptions that contained errors in print formatting - the first was using a name that did not exist mm and the second at least some python interpreters were evaluating the % before the + resulting in a problem as the display elements were spread over 2 sub-strings.  The .sjb in on the version string was just so that I could distinguish versions.